### PR TITLE
Save full forecast, once every 30 minutes

### DIFF
--- a/forecast_blend/app.py
+++ b/forecast_blend/app.py
@@ -85,6 +85,7 @@ def app(gsps: List[int] = None):
         # - forecast_value_last_seven_days
         # - forecast_value
         # tables, as we will end up doubling the size of this table.
+        session.add_all(forecasts)
         assert len(forecasts) > 0, "No forecasts made"
         assert len(forecasts[0].forecast_values) > 0, "No forecast values sql made"
         logger.debug(

--- a/readme.md
+++ b/readme.md
@@ -10,6 +10,9 @@ The main application (forecast_blend/app.py)
 
 This was previously done in the API
 
+We always update the ForecastValueLatest table, 
+but we only update the ForecastValue table every 30 minutes
+
 # Details
 
 - Note we only blend forecasts if they are made within 2 hours. 

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,6 +1,6 @@
 import logging
 
-from app import app
+from app import app, is_last_forecast_made_before_last_30_minutes_step
 from nowcasting_datamodel.models import LocationSQL
 from nowcasting_datamodel.models.forecast import (
     ForecastSQL,
@@ -10,6 +10,20 @@ from nowcasting_datamodel.models.forecast import (
 )
 
 logger = logging.getLogger(__name__)
+
+
+def test_is_last_forecast_longer_30_minutes(db_session):
+
+    assert is_last_forecast_made_before_last_30_minutes_step(db_session)
+
+
+def test_is_last_forecast_longer_30_minutes_dont_create(db_session, forecasts):
+
+    # make sure model is "blend"
+    f = db_session.query(ForecastSQL).all()
+    f[0].model.name = "blend"
+
+    assert not is_last_forecast_made_before_last_30_minutes_step(db_session)
 
 
 def test_app(db_session, forecasts):
@@ -28,9 +42,37 @@ def test_app(db_session, forecasts):
 
     app(gsps=list(range(0, 11)))
 
+    assert len(db_session.query(ForecastValueSQL).all()) == (23 + 11) * 16
+    assert len(db_session.query(ForecastValueSevenDaysSQL).all()) == (23 + 11) * 16
+    assert len(db_session.query(ForecastSQL).all()) == 46 + 11 * 2  # historic and not
+    assert len(db_session.query(ForecastValueLatestSQL).all()) == 34 * 16
+
+
+def test_app_twice(db_session, forecasts):
+
+    # Check the number forecasts have been made
+    # (10 GSPs + 1 National) = 11 forecasts
+    # This is for PVnet and CNN, but National_xg only is national
+    # 11 + 11 + 1 = 23
+    # Doubled for historic and forecast
+    assert len(db_session.query(ForecastSQL).all()) == 46
+    assert len(db_session.query(LocationSQL).all()) == 11
+    # 11 GSPs * 16 time steps in forecast
     assert len(db_session.query(ForecastValueSQL).all()) == 23 * 16
+    assert len(db_session.query(ForecastValueLatestSQL).all()) == 23 * 16
     assert len(db_session.query(ForecastValueSevenDaysSQL).all()) == 23 * 16
 
-    # now added blend model
-    assert len(db_session.query(ForecastSQL).all()) == 46 + 11
-    assert len(db_session.query(ForecastValueLatestSQL).all()) == (23 + 11) * 16
+    app(gsps=list(range(0, 11)))
+
+    assert len(db_session.query(ForecastValueSQL).all()) == (23 + 11) * 16
+    assert len(db_session.query(ForecastValueSevenDaysSQL).all()) == (23 + 11) * 16
+    assert len(db_session.query(ForecastSQL).all()) == 46 + 11 * 2  # historic and not
+    assert len(db_session.query(ForecastValueLatestSQL).all()) == 34 * 16
+
+    app(gsps=list(range(0, 11)))
+
+    # none should change, as only ForecastValueLatestSQL is being updated
+    assert len(db_session.query(ForecastValueSQL).all()) == (23 + 11) * 16
+    assert len(db_session.query(ForecastValueSevenDaysSQL).all()) == (23 + 11) * 16
+    assert len(db_session.query(ForecastSQL).all()) == 46 + 11 * 2  # historic and not
+    assert len(db_session.query(ForecastValueLatestSQL).all()) == 34 * 16


### PR DESCRIPTION
# Pull Request

## Description

Make sure forecasts are saved. 
But only save these once every 30 mintues, as we don't want o over load ForecastSQL and ForecastValuesSQL table

## How Has This Been Tested?

CI tests

- [ ] Yes

## Checklist:

- [ ] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked my code and corrected any misspellings
