### PR TITLE
Round start time

### DIFF
--- a/forecast_blend/app.py
+++ b/forecast_blend/app.py
@@ -47,6 +47,11 @@ def app(gsps: List[int] = None):
 
     # get utc now minus 1 hour, for the start time of these blending
     start_datetime = datetime.now(tz=timezone.utc) - timedelta(hours=1)
+    # round up to nearest 30 minutes
+    if start_datetime.minute < 30:
+        start_datetime = start_datetime.replace(minute=30, second=0, microsecond=0)
+    else:
+        start_datetime = start_datetime.replace(hour=start_datetime.hour + 1, minute=0, second=0, microsecond=0)
 
     with connection.get_session() as session:
 

--- a/forecast_blend/app.py
+++ b/forecast_blend/app.py
@@ -51,7 +51,9 @@ def app(gsps: List[int] = None):
     if start_datetime.minute < 30:
         start_datetime = start_datetime.replace(minute=30, second=0, microsecond=0)
     else:
-        start_datetime = start_datetime.replace(hour=start_datetime.hour + 1, minute=0, second=0, microsecond=0)
+        start_datetime = start_datetime.replace(
+            hour=start_datetime.hour + 1, minute=0, second=0, microsecond=0
+        )
 
     with connection.get_session() as session:
 

--- a/forecast_blend/weights.py
+++ b/forecast_blend/weights.py
@@ -107,6 +107,7 @@ def make_weights_df(
         # add the first weight to the dataframe, from  start_datetime to start_datetime_now.
         # This could be for the two days before now
         if i == 0:
+            logger.debug(f"Making weights for {start_datetime} to {start_datetime_now} of {start_weight}")
             weights_df = pd.DataFrame(
                 index=pd.date_range(start=start_datetime, end=start_datetime_now, freq="30min")
             )


### PR DESCRIPTION
# Pull Request

## Description

Make sure start datetime is rounded up to nearest 30 minutes, this makes the blending work properly
Fixes #

## How Has This Been Tested?

CI test and ran locally

- [ ] Yes


## Checklist:

- [ ] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked my code and corrected any misspellings
