### PR TITLE
blend plevels like we do for main variable

### DIFF
--- a/forecast_blend/app.py
+++ b/forecast_blend/app.py
@@ -73,7 +73,6 @@ def app(gsps: List[int] = None):
                 session=session,
                 gsp_id=gsp_id,
                 start_datetime=start_datetime,
-                properties_model="National_xg",
                 weights=weights,
                 model_names=["cnn", "National_xg", "pvnet_v2"],
             )

--- a/forecast_blend/blend.py
+++ b/forecast_blend/blend.py
@@ -170,7 +170,7 @@ def add_p_levels_to_forecast_values(
     blended_df = blended_df.merge(blended_on_p_values, on=["target_time"], how="left")
 
     # format plevels back to dict
-    properties_only_df.rename(columns={'plevel_10': '10', 'plevel_90': '90'}, inplace=True)
+    blended_df.rename(columns={'plevel_10': '10', 'plevel_90': '90'}, inplace=True)
     blended_df["properties"] = blended_df[["10", "90"]].apply(
         lambda x: json.loads(x.to_json()), axis=1
     )

--- a/forecast_blend/blend.py
+++ b/forecast_blend/blend.py
@@ -138,7 +138,7 @@ def add_p_levels_to_forecast_values(
 
     # get properties out of json
     properties_only_df = pd.json_normalize(all_model_df["properties"])
-    properties_only_df.rename(columns={'10':'plevel_10','90':'plevel_90'})
+    properties_only_df.rename(columns={'10':'plevel_10','90':'plevel_90'}, inplace=True)
     properties_only_df = pd.concat(
         [all_model_df[["target_time", "model_name", "adjust_mw"]], properties_only_df], axis=1
     )
@@ -170,7 +170,7 @@ def add_p_levels_to_forecast_values(
     blended_df = blended_df.merge(blended_on_p_values, on=["target_time"], how="left")
 
     # format plevels back to dict
-    properties_only_df.rename(columns={'plevel_10': '10', 'plevel_90': '90'})
+    properties_only_df.rename(columns={'plevel_10': '10', 'plevel_90': '90'}, inplace=True)
     blended_df["properties"] = blended_df[["10", "90"]].apply(
         lambda x: json.loads(x.to_json()), axis=1
     )

--- a/forecast_blend/utils.py
+++ b/forecast_blend/utils.py
@@ -136,7 +136,9 @@ def convert_df_to_list_forecast_values(forecast_values_blended: pd.DataFrame):
     return forecast_values
 
 
-def blend_forecasts_together(forecast_values_all_model, weights_df, variable_to_blend: str = "expected_power_generation_megawatts"):
+def blend_forecasts_together(forecast_values_all_model,
+                             weights_df,
+                             column_name_to_blend: str = "expected_power_generation_megawatts"):
     """
     Blend the forecasts together using the weights_df
 
@@ -144,7 +146,7 @@ def blend_forecasts_together(forecast_values_all_model, weights_df, variable_to_
         'expected_power_generation_megawatts', 'adjust_mw', 'model_name'
     :param weights_df: Dataframe of weights with columns of the model name,
         and index of target times
-    :param variable_to_blend: The variable to blend, either "expected_power_generation_megawatts"
+    :param column_name_to_blend: The variable to blend, either "expected_power_generation_megawatts"
     :return: Dataframe with the columns
         'target_time',
         'expected_power_generation_megawatts',
@@ -201,11 +203,11 @@ def blend_forecasts_together(forecast_values_all_model, weights_df, variable_to_
 
         # merge the forecast values and weights together
         forecast_values_one_target_time = forecast_values_one_target_time[
-            ["model_name", variable_to_blend, "adjust_mw", "weight"]
+            ["model_name", column_name_to_blend, "adjust_mw", "weight"]
         ]
 
         forecast_values_one_target_time_blend = blend_together_one_target_time(
-            forecast_values_one_target_time, target_time, variable_to_blend=variable_to_blend
+            forecast_values_one_target_time, target_time, variable_to_blend=column_name_to_blend
         )
 
         total_weights_used = forecast_values_one_target_time_blend["weight"].iloc[0]
@@ -247,7 +249,7 @@ def blend_forecasts_together(forecast_values_all_model, weights_df, variable_to_
 
                     # blend together
                     forecast_values_one_target_time_blend = blend_together_one_target_time(
-                        forecast_values_one_target_time, target_time, variable_to_blend
+                        forecast_values_one_target_time, target_time, column_name_to_blend
                     )
                     total_weights_used = forecast_values_one_target_time_blend["weight"].iloc[0]
 

--- a/readme.md
+++ b/readme.md
@@ -17,7 +17,7 @@ but we only update the ForecastValue table every 30 minutes
 
 - Note we only blend forecasts if they are made within 2 hours. 
 If all forecasts are older than this, then all forecasts are used.
-- Currently the probablistics forecasts come from national_xg model. 
+- The probabilistic forecasts are now blended using the same method as the expected value
 
 # Tests
 

--- a/tests/test_blend.py
+++ b/tests/test_blend.py
@@ -75,7 +75,6 @@ def test_get_blend_forecast_values_latest_one_model(db_session):
         gsp_id=f1[0].location.gsp_id,
         start_datetime=datetime(2023, 1, 1, 0, 0, tzinfo=timezone.utc),
         model_names=["test_1"],
-        properties_model="test_1",
     )
 
     assert len(forecast_values_read) == 2
@@ -119,7 +118,6 @@ def test_get_blend_forecast_values_latest_two_model_read_one(db_session):
         gsp_id=f1[0].location.gsp_id,
         start_datetime=datetime(2023, 1, 1, 0, 0, tzinfo=timezone.utc),
         model_names=["test_1"],
-        properties_model="test_1",
     )
 
     assert len(forecast_values_read) == 2
@@ -183,7 +181,6 @@ def test_get_blend_forecast_values_latest_two_model_read_two(db_session):
         gsp_id=f1[0].location.gsp_id,
         start_datetime=datetime(2022, 12, 31, 0, 0, tzinfo=timezone.utc),
         model_names=["test_1", "test_2"],
-        properties_model="test_1",
     )
 
     assert len(forecast_values_read) == 7
@@ -202,8 +199,8 @@ def test_get_blend_forecast_values_latest_two_model_read_two(db_session):
     assert forecast_values_read[1]._properties == {"10": 0.9, "90": 1.1}
     assert forecast_values_read[2]._properties == {"10": 0.9, "90": 1.1}
     assert forecast_values_read[3]._properties == {"10": 0.9, "90": 1.1}
-    assert forecast_values_read[4]._properties == {"10": 1.9, "90": 2.1}
-    assert forecast_values_read[5]._properties == {"10": 2.9, "90": 3.1}
+    assert forecast_values_read[4]._properties == {"10": 1.8, "90": 2.2}
+    assert forecast_values_read[5]._properties == {"10": 2.7, "90": 3.3}
 
     assert forecast_values_read[0]._adjust_mw == 0
     assert forecast_values_read[1]._adjust_mw == 0
@@ -259,7 +256,6 @@ def test_get_blend_forecast_values_two_models_plevel_second(db_session):
         gsp_id=f1[0].location.gsp_id,
         start_datetime=datetime(2022, 12, 31, 0, 0, tzinfo=timezone.utc),
         model_names=["test_2", "test_1"],
-        properties_model="test_1",
     )
 
     assert len(forecast_values_read) == 7
@@ -276,9 +272,9 @@ def test_get_blend_forecast_values_two_models_plevel_second(db_session):
 
     assert forecast_values_read[0]._properties == {"10": 0.9, "90": 1.1}
     assert forecast_values_read[1]._properties == {"10": 0.9, "90": 1.1}
-    assert forecast_values_read[2]._properties == {"10": 1.9, "90": 2.1}
-    assert forecast_values_read[3]._properties == {"10": 1.9, "90": 2.1}
-    assert forecast_values_read[4]._properties == {"10": 1.4, "90": 1.6}
+    assert forecast_values_read[2]._properties == {"10": 1.8, "90": 2.2}
+    assert forecast_values_read[3]._properties == {"10": 1.8, "90": 2.2}
+    assert forecast_values_read[4]._properties == {"10": 1.35, "90": 1.65}
     assert forecast_values_read[5]._properties == {"10": 0.9, "90": 1.1}
 
     assert forecast_values_read[0]._adjust_mw == 0
@@ -315,6 +311,7 @@ def test_get_blend_forecast_values_latest_negative(db_session):
                 target_time=datetime(2023, 1, 1, tzinfo=timezone.utc) + timedelta(minutes=t),
                 model_id=model.id,
                 adjust_mw=adjust,
+                properties={"10": 0.9, "90": 1.1},
             )
             for t in forecast_horizon_minutes
         ]
@@ -327,7 +324,6 @@ def test_get_blend_forecast_values_latest_negative(db_session):
         gsp_id=f1[0].location.gsp_id,
         start_datetime=datetime(2023, 1, 1, 0, 0, tzinfo=timezone.utc),
         model_names=["test_1", "test_2"],
-        properties_model="test_1",
     )
 
     assert len(forecast_values_read) == 4


### PR DESCRIPTION
# Pull Request

## Description

Blend plevel like we do main expectation value (or the mean value). This means 
0-7 hours are pvenet
7-8 are mix
8 onwards are National_xg

Before we were just taking National_xg probability levels

before (from pro)

![Screenshot 2023-10-04 at 18 22 30](https://github.com/openclimatefix/uk-pv-forecast-blend/assets/34686298/a9033607-829a-4859-b693-4d4def85690a)


after (from dev- after running locally)

![Screenshot 2023-10-04 at 18 22 20](https://github.com/openclimatefix/uk-pv-forecast-blend/assets/34686298/4537d725-b6d8-418f-9b21-332e420a6906)



Fixes #12 

## How Has This Been Tested?

- [x] CI tests
- [x] run locally, re ran on 2023-10-04 and probablisitic looked reasonable

- [x] Yes

## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my code and corrected any misspellings
