### PR TITLE
add mermaid diagram

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -19,6 +19,36 @@ but we only update the ForecastValue table every 30 minutes
 If all forecasts are older than this, then all forecasts are used.
 - Currently the probablistics forecasts come from national_xg model. 
 
+```mermaid
+  graph TD;
+      subgraph App
+      S(Start) --> LF
+      LF(Load All Forecasts);
+      LF --> Filter(Filter Forecasts);
+      Filter -->  Blend[Blend \n Expected values];
+      Blend --> N4(Blend Probabilistic \n- only for National);
+      N4 --> S(Save Forecast)
+      S --> F(Finish)
+      end
+      
+      subgraph Blending
+    A(All Forecasts);
+    W2(Weights);
+    A --> SUT(Split unique 'target times' \n and not);
+    SUT --> |Unique Target times| B
+    SUT --> |Duplicated Target times| C(Loop over each \n target time)
+    C --> BW
+    W2 --> BW
+    BW(Blend using weights) --> SumCheck
+    SumCheck{At least one \n forecast available} --> |yes| B
+    SumCheck --> |no| Blend2(Blend forecast with \n next set of weights)
+    Blend2 --> SumCheck2
+    SumCheck2{At least one \n forecast available} --> |yes| B
+    SumCheck2 --> |no| BB(Break)
+    B(Blended \n Forecast)
+    end
+```
+
 # Tests
 
 Tests are in the tests folder and can be run using pytest


### PR DESCRIPTION
# Pull Request

## Description

Add diagram how how things are blended

![Screenshot 2023-10-09 at 08 39 52](https://github.com/openclimatefix/uk-pv-forecast-blend/assets/34686298/ca71172f-d87c-41f8-849c-46031a9568b0)

https://github.com/openclimatefix/uk-pv-forecast-blend/issues/14

## How Has This Been Tested?

This is just markdown changes

- [x] Yes

## Checklist:

- [ ] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked my code and corrected any misspellings
