### PR TITLE
use forecasts up to 6 hours late

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -2,6 +2,8 @@ name: Python tests
 
 on:
   push:
+  pull_request:
+    types: [ opened, reopened ]
   schedule:
     - cron: "0 12 * * 1"
 jobs:

--- a/forecast_blend/utils.py
+++ b/forecast_blend/utils.py
@@ -14,17 +14,17 @@ def check_forecast_created_utc(forecast_values_all_model) -> List[Union[str, Lis
     """
     Check if forecasts are valid.
 
-    We only consider forecast less than 2 hours old.
-    If all forecast are older than 2 hours, we used both.
+    We only consider forecast less than 6 hours old.
+    If all forecast are older than 6 hours, we used both.
 
     :param forecast_values_all_model: list of forecast
     :return: list of valid forecasts
     """
     one_forecast_created_within_timedelta = True
 
-    # if all forecasts are later than 2 hours, then we use the blend,
-    # otherwise we only use forecast less than 2 hours
-    # remove all forecasts that are older than 2 hours
+    # if all forecasts are later than 6 hours, then we use the blend,
+    # otherwise we only use forecast less than 6 hours
+    # remove all forecasts that are older than 6 hours
     forecast_values_all_model_valid = []
     for model_name, forecast_values_one_model in forecast_values_all_model:
 
@@ -32,7 +32,7 @@ def check_forecast_created_utc(forecast_values_all_model) -> List[Union[str, Lis
 
         one_forecast_created_within_timedelta = one_forecast_created > datetime.now(
             timezone.utc
-        ) - timedelta(hours=2)
+        ) - timedelta(hours=6)
 
         if one_forecast_created_within_timedelta:
             logger.debug(

--- a/readme.md
+++ b/readme.md
@@ -15,7 +15,7 @@ but we only update the ForecastValue table every 30 minutes
 
 # Details
 
-- Note we only blend forecasts if they are made within 2 hours. 
+- Note we only blend forecasts if they are made within 6 hours. 
 If all forecasts are older than this, then all forecasts are used.
 - The probabilistic forecasts are now blended using the same method as the expected value
 


### PR DESCRIPTION
# Pull Request

## Description

- increase model timeout time to 6 hours.

## How Has This Been Tested?

CI tests

- [x] Yes

## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my code and corrected any misspellings
