### PR TITLE
update the model_info field of each ForecastValue object with the model name/weight

### DIFF
--- a/forecast_blend/blend.py
+++ b/forecast_blend/blend.py
@@ -112,6 +112,12 @@ def get_blend_forecast_values_latest(
     # convert back to list of forecast values
     forecast_values = convert_df_to_list_forecast_values(forecast_values_blended)
 
+    # Update model_info for each ForecastValue
+    for forecast_value, weight_dict in zip(forecast_values, weights_df.to_dict('records')):
+        forecast_value._model_info = {
+            model: weight for model, weight in weight_dict.items() if model in model_names
+        }
+
     return forecast_values
 
 


### PR DESCRIPTION
# Pull Request

## Description

saves models and weights for each forecast, this is also related to my pr in [nowcasting_datamodel](https://github.com/openclimatefix/nowcasting_datamodel/pull/277)

Fixes #

#15 

## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have checked my code and corrected any misspellings
