### PR TITLE
timezone aware method

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,5 @@
 import os
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 
 import pytest
 from nowcasting_datamodel.connection import DatabaseConnection
@@ -10,7 +10,7 @@ from testcontainers.postgres import PostgresContainer
 
 @pytest.fixture
 def forecasts(db_session):
-    t0_datetime_utc = datetime.utcnow() + timedelta(days=2)
+    t0_datetime_utc = datetime.now(tz=timezone.utc) + timedelta(days=2)
     # time detal of 2 days is used as fake forecast are made 2 days in the past,
     # this makes them for now
     # create
@@ -35,7 +35,7 @@ def forecasts(db_session):
 
 @pytest.fixture
 def forecast_national(db_session):
-    t0_datetime_utc = datetime.utcnow() + timedelta(days=2)
+    t0_datetime_utc = datetime.now(tz=timezone.utc) + timedelta(days=2)
     # time detal of 2 days is used as fake forecast are made 2 days in the past,
     # this makes them for now
     # create


### PR DESCRIPTION
# Pull Request

## Description

the datetime.utcnow() method is considered deprecated in modern Python versions, and it's recommended to use the more explicit datetime.now(tz=datetime.timezone.utc) instead. The utcnow() method is still functional, but it's considered less clear and less timezone-aware than the alternative. I have thus replaced the deprecated method with the newer one

Fixes #

Replaced the deprecated utcnow() method with the newer one

## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [x] I have checked my code and corrected any misspellings
