### PR TITLE
update to use pvnet day ahead

### DIFF
--- a/forecast_blend/app.py
+++ b/forecast_blend/app.py
@@ -31,7 +31,7 @@ from nowcasting_datamodel.save.update import N_GSP, update_all_forecast_latest
 
 from blend import get_blend_forecast_values_latest
 from utils import get_start_datetime
-from weights import weights
+from weights import weights, model_names
 
 logger = structlog.stdlib.get_logger()
 
@@ -71,7 +71,7 @@ def app(gsps: List[int] = None):
                     gsp_id=gsp_id,
                     start_datetime=start_datetime,
                     weights=weights,
-                    model_names=["cnn", "National_xg", "pvnet_v2"],
+                    model_names=model_names,
                 )
 
                 # make Forecast SQL
@@ -117,7 +117,7 @@ def get_blend_model(session):
     """
     # get all model versions
     models = {}
-    for model_name in ["cnn", "National_xg", "pvnet_v2"]:
+    for model_name in model_names:
         model = get_model(name=model_name, session=session)
         models[model_name] = model.version
 

--- a/forecast_blend/weights.py
+++ b/forecast_blend/weights.py
@@ -41,7 +41,7 @@ weights = [
         # pvnet_v2 to pvnet_day_ahead
         "start_horizon_hour": 7,
         "end_horizon_hour": 8,
-        "start_weight": [0, 0, 1],
+        "start_weight": [1, 0, 0],
         "end_weight": [0, 1, 0],
     },
     {

--- a/forecast_blend/weights.py
+++ b/forecast_blend/weights.py
@@ -8,6 +8,8 @@ import structlog
 
 logger = structlog.stdlib.get_logger()
 
+model_names = ["pvnet_v2", "pvnet_day_ahead", "National_xg"]
+
 default_weights = [
     {
         "end_horizon_hour": 2,
@@ -27,24 +29,23 @@ default_weights = [
 
 
 # merged from
-# - cnn
 # - pvnet_v2
-# - National_xg
+# - pvnet_day_ahead
 weights = [
     {
         # pvnet_v2
         "end_horizon_hour": 7,
-        "end_weight": [0, 0, 1],
+        "end_weight": [1, 0, 0],
     },
     {
-        # pvnet_v2 to National_xg
+        # pvnet_v2 to pvnet_day_ahead
         "start_horizon_hour": 7,
         "end_horizon_hour": 8,
         "start_weight": [0, 0, 1],
         "end_weight": [0, 1, 0],
     },
     {
-        # National_xg
+        # pvnet_day_ahead
         "start_horizon_hour": 8,
         "end_horizon_hour": 36,
         "start_weight": [0, 1, 0],

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 nowcasting_datamodel==1.5.12
+numpy==1.26.4
 pandas
 freezegun
 pytest

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,6 +5,8 @@ import pytest
 from nowcasting_datamodel.connection import DatabaseConnection
 from nowcasting_datamodel.fake import make_fake_forecasts
 from nowcasting_datamodel.save.save import save
+
+from forecast_blend.weights import model_names
 from testcontainers.postgres import PostgresContainer
 
 
@@ -14,7 +16,7 @@ def forecasts(db_session):
     # time detal of 2 days is used as fake forecast are made 2 days in the past,
     # this makes them for now
     # create
-    for model_name in ["cnn", "pvnet_v2", "National_xg"]:
+    for model_name in model_names:
 
         if model_name == "National_xg":
             gsp_ids = [0]
@@ -39,7 +41,7 @@ def forecast_national(db_session):
     # time detal of 2 days is used as fake forecast are made 2 days in the past,
     # this makes them for now
     # create
-    for model_name in ["cnn", "pvnet_v2", "National_xg"]:
+    for model_name in model_names:
 
         gsp_ids = [0]
 


### PR DESCRIPTION
# Pull Request

## Description

Update to blend `pvnet` and `pvnet_day_ahead`
`National_xg` is still loaded as a back up

Also did a tiny bit of refactoring to make the model names a bit more standard

## How Has This Been Tested?

CI tests

- [x] Yes

## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my code and corrected any misspellings
