### PR TITLE
Blend ecwmf only

### DIFF
--- a/forecast_blend/weights.py
+++ b/forecast_blend/weights.py
@@ -8,7 +8,7 @@ import structlog
 
 logger = structlog.stdlib.get_logger()
 
-model_names = ["pvnet_v2", "pvnet_day_ahead", "pnvet_ecmwf", "National_xg"]
+model_names = ["pvnet_v2", "pvnet_day_ahead", "pvnet_ecmwf", "National_xg"]
 
 # merged from
 # - pvnet_v2
@@ -36,7 +36,7 @@ weights = [
     {
         # backup to use ecmwf
         "start_horizon_hour": 999,
-        "end_horizon_hour": 999,
+        "end_horizon_hour": 1000,
         "start_weight": [0, 0, 1, 0],
         "end_weight": [0, 0, 1, 0],
     },

--- a/forecast_blend/weights.py
+++ b/forecast_blend/weights.py
@@ -35,8 +35,8 @@ weights = [
     },
     {
         # backup to use ecmwf
-        # this works becasue if pvnet or pvnet da is not there,
-        # then the blend is made on any future weight settings. 
+        # this works because if pvnet or pvnet da is not there,
+        # then the blend is made on any future weight settings.
         "start_horizon_hour": 999,
         "end_horizon_hour": 1000,
         "start_weight": [0, 0, 1, 0],

--- a/forecast_blend/weights.py
+++ b/forecast_blend/weights.py
@@ -8,8 +8,41 @@ import structlog
 
 logger = structlog.stdlib.get_logger()
 
-model_names = ["pvnet_v2", "pvnet_day_ahead", "National_xg"]
+model_names = ["pvnet_v2", "pvnet_day_ahead", "pnvet_ecmwf", "National_xg"]
 
+# merged from
+# - pvnet_v2
+# - pvnet_day_ahead
+weights = [
+    {
+        # pvnet_v2
+        "end_horizon_hour": 7,
+        "end_weight": [1, 0, 0, 0],
+    },
+    {
+        # pvnet_v2 to pvnet_day_ahead
+        "start_horizon_hour": 7,
+        "end_horizon_hour": 8,
+        "start_weight": [1, 0, 0, 0],
+        "end_weight": [0, 1, 0, 0],
+    },
+    {
+        # pvnet_day_ahead
+        "start_horizon_hour": 8,
+        "end_horizon_hour": 36,
+        "start_weight": [0, 1, 0, 0],
+        "end_weight": [0, 1, 0, 0],
+    },
+    {
+        # backup to use ecmwf
+        "start_horizon_hour": 999,
+        "end_horizon_hour": 999,
+        "start_weight": [0, 0, 1, 0],
+        "end_weight": [0, 0, 1, 0],
+    },
+]
+
+# used just for testing. Moved to test file? TODO
 default_weights = [
     {
         "end_horizon_hour": 2,
@@ -27,31 +60,6 @@ default_weights = [
     },
 ]
 
-
-# merged from
-# - pvnet_v2
-# - pvnet_day_ahead
-weights = [
-    {
-        # pvnet_v2
-        "end_horizon_hour": 7,
-        "end_weight": [1, 0, 0],
-    },
-    {
-        # pvnet_v2 to pvnet_day_ahead
-        "start_horizon_hour": 7,
-        "end_horizon_hour": 8,
-        "start_weight": [1, 0, 0],
-        "end_weight": [0, 1, 0],
-    },
-    {
-        # pvnet_day_ahead
-        "start_horizon_hour": 8,
-        "end_horizon_hour": 36,
-        "start_weight": [0, 1, 0],
-        "end_weight": [0, 1, 0],
-    },
-]
 
 
 def make_weights_df(

--- a/forecast_blend/weights.py
+++ b/forecast_blend/weights.py
@@ -35,6 +35,8 @@ weights = [
     },
     {
         # backup to use ecmwf
+        # this works becasue if pvnet or pvnet da is not there,
+        # then the blend is made on any future weight settings. 
         "start_horizon_hour": 999,
         "end_horizon_hour": 1000,
         "start_weight": [0, 0, 1, 0],

--- a/readme.md
+++ b/readme.md
@@ -18,7 +18,7 @@ but we only update the ForecastValue table every 30 minutes
 - Note we only blend forecasts if they are made within 6 hours. 
 If all forecasts are older than this, then all forecasts are used.
 - The probabilistic forecasts are now blended using the same method as the expected value
-- We current intial take `Pvnet`, then blend it with `PVnet DA`. `PVnet ECMWF` is used as a back up, and final `National-xg` is a final backup. 
+- We current take `Pvnet`, then blend it with `PVnet DA`. `PVnet ECMWF` is used as a backup, and final `National-xg` is a final backup. 
 
 ```mermaid
   graph TD;

--- a/readme.md
+++ b/readme.md
@@ -18,6 +18,7 @@ but we only update the ForecastValue table every 30 minutes
 - Note we only blend forecasts if they are made within 6 hours. 
 If all forecasts are older than this, then all forecasts are used.
 - The probabilistic forecasts are now blended using the same method as the expected value
+- We current intial take `Pvnet`, then blend it with `PVnet DA`. `PVnet ECMWF` is used as a back up, and final `National-xg` is a final backup. 
 
 ```mermaid
   graph TD;

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -57,6 +57,33 @@ def forecast_national(db_session):
 
     return None
 
+@pytest.fixture
+def forecast_national_ecmwf_and_xg(db_session):
+    t0_datetime_utc = (datetime.now(tz=timezone.utc) + timedelta(days=2)).replace(minute=0, second=0, microsecond=0)
+    # time detal of 2 days is used as fake forecast are made 2 days in the past,
+    # this makes them for now
+    # create
+    model_names_ecmwf_and_xg = ["pvnet_ecmwf", "National_xg"]
+    for i in range(len(model_names_ecmwf_and_xg)):
+        model_name = model_names_ecmwf_and_xg[i]
+
+        gsp_ids = [0]
+
+        forecasts = make_fake_forecasts(
+            gsp_ids=gsp_ids,
+            session=db_session,
+            model_name=model_name,
+            n_fake_forecasts=16,
+            t0_datetime_utc=t0_datetime_utc,  # add
+        )  # add
+        for f in forecasts:
+            for fv in f.forecast_values:
+                fv.expected_power_generation_megawatts = i
+
+        save(forecasts=forecasts, session=db_session, apply_adjuster=False)
+
+    return None
+
 
 """
 This is a bit complicated and sensitive to change

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -31,21 +31,22 @@ def test_app(db_session, forecasts):
     # Check the number forecasts have been made
     # (10 GSPs + 1 National) = 11 forecasts
     # This is for PVnet and CNN, but National_xg only is national
-    # 11 + 11 + 1 = 23
+    # 11 + 11 + 11+ 1 = 34
+    N = 34
     # Doubled for historic and forecast
-    assert len(db_session.query(ForecastSQL).all()) == 46
+    assert len(db_session.query(ForecastSQL).all()) == N * 2
     assert len(db_session.query(LocationSQL).all()) == 11
     # 11 GSPs * 16 time steps in forecast
-    assert len(db_session.query(ForecastValueSQL).all()) == 23 * 16
-    assert len(db_session.query(ForecastValueLatestSQL).all()) == 23 * 16
-    assert len(db_session.query(ForecastValueSevenDaysSQL).all()) == 23 * 16
+    assert len(db_session.query(ForecastValueSQL).all()) == N * 16
+    assert len(db_session.query(ForecastValueLatestSQL).all()) == N * 16
+    assert len(db_session.query(ForecastValueSevenDaysSQL).all()) == N * 16
 
     app(gsps=list(range(0, 11)))
 
-    assert len(db_session.query(ForecastValueSQL).all()) == (23 + 11) * 16
-    assert len(db_session.query(ForecastValueSevenDaysSQL).all()) == (23 + 11) * 16
-    assert len(db_session.query(ForecastSQL).all()) == 46 + 11 * 2  # historic and not
-    assert len(db_session.query(ForecastValueLatestSQL).all()) == 34 * 16
+    assert len(db_session.query(ForecastValueSQL).all()) == (N + 11) * 16
+    assert len(db_session.query(ForecastValueSevenDaysSQL).all()) == (N + 11) * 16
+    assert len(db_session.query(ForecastSQL).all()) == 2*N + 11 * 2  # historic and not
+    assert len(db_session.query(ForecastValueLatestSQL).all()) == (N + 11) * 16
 
 
 def test_app_twice(db_session, forecasts):
@@ -53,50 +54,52 @@ def test_app_twice(db_session, forecasts):
     # Check the number forecasts have been made
     # (10 GSPs + 1 National) = 11 forecasts
     # This is for PVnet and CNN, but National_xg only is national
-    # 11 + 11 + 1 = 23
+    # 11 + 11 + 11 +1 = 34
+    N = 34
     # Doubled for historic and forecast
-    assert len(db_session.query(ForecastSQL).all()) == 46
+    assert len(db_session.query(ForecastSQL).all()) == 2 * N
     assert len(db_session.query(LocationSQL).all()) == 11
     # 11 GSPs * 16 time steps in forecast
-    assert len(db_session.query(ForecastValueSQL).all()) == 23 * 16
-    assert len(db_session.query(ForecastValueLatestSQL).all()) == 23 * 16
-    assert len(db_session.query(ForecastValueSevenDaysSQL).all()) == 23 * 16
+    assert len(db_session.query(ForecastValueSQL).all()) == N * 16
+    assert len(db_session.query(ForecastValueLatestSQL).all()) == N * 16
+    assert len(db_session.query(ForecastValueSevenDaysSQL).all()) == N * 16
 
     app(gsps=list(range(0, 11)))
 
-    assert len(db_session.query(ForecastValueSQL).all()) == (23 + 11) * 16
-    assert len(db_session.query(ForecastValueSevenDaysSQL).all()) == (23 + 11) * 16
-    assert len(db_session.query(ForecastSQL).all()) == 46 + 11 * 2  # historic and not
-    assert len(db_session.query(ForecastValueLatestSQL).all()) == 34 * 16
+    assert len(db_session.query(ForecastValueSQL).all()) == (N + 11) * 16
+    assert len(db_session.query(ForecastValueSevenDaysSQL).all()) == (N + 11) * 16
+    assert len(db_session.query(ForecastSQL).all()) == (2*N) + 11 * 2  # historic and not
+    assert len(db_session.query(ForecastValueLatestSQL).all()) == (N+11) * 16
 
     app(gsps=list(range(0, 11)))
 
     # none should change, as only ForecastValueLatestSQL is being updated
-    assert len(db_session.query(ForecastValueSQL).all()) == (23 + 11) * 16
-    assert len(db_session.query(ForecastValueSevenDaysSQL).all()) == (23 + 11) * 16
-    assert len(db_session.query(ForecastSQL).all()) == 46 + 11 * 2  # historic and not
-    assert len(db_session.query(ForecastValueLatestSQL).all()) == 34 * 16
+    assert len(db_session.query(ForecastValueSQL).all()) == (N + 11) * 16
+    assert len(db_session.query(ForecastValueSevenDaysSQL).all()) == (N + 11) * 16
+    assert len(db_session.query(ForecastSQL).all()) == 2*N + 11 * 2  # historic and not
+    assert len(db_session.query(ForecastValueLatestSQL).all()) == (N+11) * 16
 
 
 def test_app_only_national(db_session, forecast_national):
 
     # Check the number forecasts have been made
     # 1 National)
-    # This is for PVnet and CNN, but National_xg only is national
-    # 3
+    # This is for PVnet, PVnet ecmwf and CNN, but National_xg only is national
+    # 4
+    N = 4
     # Doubled for historic and forecast
-    assert len(db_session.query(ForecastSQL).all()) == 6
+    assert len(db_session.query(ForecastSQL).all()) == 2*N
     assert len(db_session.query(LocationSQL).all()) == 1
     #  16 time steps in forecast
-    assert len(db_session.query(ForecastValueSQL).all()) == 3 * 16
-    assert len(db_session.query(ForecastValueLatestSQL).all()) == 3 * 16
-    assert len(db_session.query(ForecastValueSevenDaysSQL).all()) == 3 * 16
+    assert len(db_session.query(ForecastValueSQL).all()) == N * 16
+    assert len(db_session.query(ForecastValueLatestSQL).all()) == N * 16
+    assert len(db_session.query(ForecastValueSevenDaysSQL).all()) == N * 16
 
     app(gsps=list(range(0, 2)))
 
-    assert len(db_session.query(ForecastValueSQL).all()) == 4 * 16
-    assert len(db_session.query(ForecastValueSevenDaysSQL).all()) == 4 * 16
-    assert len(db_session.query(ForecastSQL).all()) == 8   # historic and not
-    assert len(db_session.query(ForecastValueLatestSQL).all()) == 4 * 16
+    assert len(db_session.query(ForecastValueSQL).all()) == (N+1) * 16
+    assert len(db_session.query(ForecastValueSevenDaysSQL).all()) == (N+1) * 16
+    assert len(db_session.query(ForecastSQL).all()) == 2*(N+1)   # historic and not
+    assert len(db_session.query(ForecastValueLatestSQL).all()) == (N+1) * 16
 
 

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -31,8 +31,8 @@ def test_app(db_session, forecasts):
 
     # Check the number forecasts have been made
     # (10 GSPs + 1 National) = 11 forecasts
-    # This is for PVnet and CNN, but National_xg only is national
-    # 11 + 11 + 11+ 1 = 34
+    # This is for PVnet and PVnet DA, PVNet ECMWF, National-xg (which is only National)
+    # 11 + 11 + 11 + 1 = 34
     N = 34
     # Doubled for historic and forecast
     assert len(db_session.query(ForecastSQL).all()) == N * 2
@@ -54,7 +54,7 @@ def test_app_twice(db_session, forecasts):
 
     # Check the number forecasts have been made
     # (10 GSPs + 1 National) = 11 forecasts
-    # This is for PVnet and CNN, but National_xg only is national
+    # This is for PVnet and PVnet DA, PVNet ECMWF, National-xg (which is only National)
     # 11 + 11 + 11 +1 = 34
     N = 34
     # Doubled for historic and forecast
@@ -85,7 +85,7 @@ def test_app_only_national(db_session, forecast_national):
 
     # Check the number forecasts have been made
     # 1 National)
-    # This is for PVnet, PVnet ecmwf and CNN, but National_xg only is national
+    # This is for PVnet and PVnet DA, PVNet ECMWF, National-xg (which is only National)
     # 4
     N = 4
     # Doubled for historic and forecast


### PR DESCRIPTION
# Pull Request

## Description

If pvnet and pvnet day is not working, blend in pvnet_ecmwf only, instead of national_xg
If pvnet_ecmwf not there, use national_xg

- add the pvnet_ecmwf model, which maent updating the tests
- added pvnet_ecmwf to the weights, 
- added a test to check it works

Helps with https://github.com/openclimatefix/uk-pvnet-app/issues/123

## How Has This Been Tested?

CI tests + added extra

- [x] Yes

## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my code and corrected any misspellings
