### PR TITLE
feat: add SAVE_TO_DB environment variable to control database saving

### DIFF
--- a/forecast_blend/app.py
+++ b/forecast_blend/app.py
@@ -67,6 +67,7 @@ async def app(gsps: list[int] | None = None) -> None:
     """run main app"""
 
     blend_name = os.getenv("BLEND_NAME", "blend")
+    save_to_db = os.getenv("SAVE_TO_DB", "true").lower() == "true"
     allow_cloudcasting = os.getenv("ALLOW_CLOUDCASTING", "false").lower()=="true"
 
     exclude_models = None if allow_cloudcasting else ["pvnet_cloud"]
@@ -178,7 +179,9 @@ async def app(gsps: list[int] | None = None) -> None:
         # tables, as we will end up doubling the size of this table.
         assert len(forecasts) > 0, "No forecasts made"
         assert len(forecasts[0].forecast_values) > 0, "No forecast values sql made"
-        if is_last_forecast_made_before_last_30_minutes_step(session=session, blend_name=blend_name):
+        if not save_to_db:
+            logger.info("Skipping database save (SAVE_TO_DB=false)")
+        elif is_last_forecast_made_before_last_30_minutes_step(session=session, blend_name=blend_name):
             logger.debug(f"Saving {len(forecasts)} forecasts")
             save(
                 session=session,


### PR DESCRIPTION
# Pull Request

## Description

Added an env variable to stop saving forecasts to database

Fixes #https://github.com/openclimatefix/client-private/issues/319

## How Has This Been Tested?

- [x] Tested with dev-dataplatform

## Additional note:
With SAVE_TO_DB flag being switched to false, some tests will fail

## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my code and corrected any misspellings
