### PR TITLE
use 351 gsps

### DIFF
--- a/forecast_blend/app.py
+++ b/forecast_blend/app.py
@@ -29,8 +29,8 @@ import pandas as pd
 
 __version__ = "1.1.9"
 
-# GB has 342 GSPs
-N_GSP = 342
+# GB has 351 GSPs (some of these are legacy)
+N_GSP = 351 
 
 sentry_sdk.init(
     dsn=os.getenv("SENTRY_DSN"),


### PR DESCRIPTION
# Pull Request

## Description

Use 351 gsps (updated from 342)

Even if they are empty it will work (this happens already for legacy gsp_id=5)

https://github.com/openclimatefix/airflow-dags/issues/730

## How Has This Been Tested?

- CI tests

## Checklist:

- [ ] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked my code and corrected any misspellings
