### PR TITLE
feat: add support for additional probability levels in forecasts and tests

### DIFF
--- a/forecast_blend/blend.py
+++ b/forecast_blend/blend.py
@@ -147,15 +147,18 @@ def add_p_levels_to_forecast_values(
     logger.debug("Adding properties to blended forecast values")
     all_model_df.reset_index(inplace=True, drop=True)
 
+    # the plevels (other than p50) that may be present for National forecasts
+    p_levels = ["2", "10", "25", "75", "90", "98"]
+
     # get properties out of json if they exist
     if "properties" in all_model_df.columns:
         properties_only_df = pd.json_normalize(all_model_df["properties"])
         properties_only_df.rename(
-            columns={"10": "plevel_10", "90": "plevel_90"}, inplace=True
+            columns={p: f"plevel_{p}" for p in p_levels}, inplace=True
         )
     else:
         # If properties are missing, create empty columns
-        properties_only_df = pd.DataFrame(columns=["plevel_10", "plevel_90"])
+        properties_only_df = pd.DataFrame(columns=[f"plevel_{p}" for p in p_levels])
 
     properties_only_df = pd.concat(
         [all_model_df[["target_time", "model_name", "adjust_mw"]], properties_only_df],
@@ -171,7 +174,8 @@ def add_p_levels_to_forecast_values(
 
     # blend together the p values if they exist
     blended_on_p_values = None
-    for p_level in ["plevel_10", "plevel_90"]:
+    for p in p_levels:
+        p_level = f"plevel_{p}"
         if p_level in properties_only_df.columns:
             blended_on_p_value = blend_forecasts_together(
                 properties_only_df, weights_df, column_name_to_blend=p_level
@@ -190,14 +194,21 @@ def add_p_levels_to_forecast_values(
         # add properties to blended forecast values if they exist
         blended_df = blended_df.merge(blended_on_p_values, on=["target_time"], how="left")
 
+        # the plevels that were actually present and blended
+        present_p_levels = [p for p in p_levels if f"plevel_{p}" in blended_df.columns]
+
         # format plevels back to dict
-        blended_df.rename(columns={"plevel_10": "10", "plevel_90": "90"}, inplace=True)
-        blended_df["properties"] = blended_df[["10", "90"]].apply(
-            lambda x: json.loads(x.to_json()) if pd.notnull(x).all() else {}, axis=1
+        blended_df.rename(
+            columns={f"plevel_{p}": p for p in present_p_levels}, inplace=True
+        )
+        blended_df["properties"] = blended_df[present_p_levels].apply(
+            lambda x: json.loads(x.dropna().to_json()), axis=1
         )
 
-        # rename
-        blended_df.rename(columns={"10": "p10_mw", "90": "p90_mw"}, inplace=True)
+        # rename to p<level>_mw columns
+        blended_df.rename(
+            columns={p: f"p{p}_mw" for p in present_p_levels}, inplace=True
+        )
 
     else:
         # If blended_on_p_values is None, assign an empty dictionary to properties

--- a/forecast_blend/forecast/data_platform.py
+++ b/forecast_blend/forecast/data_platform.py
@@ -166,10 +166,9 @@ async def get_forecast_values_from_data_platform(
         other_stats = getattr(dp_value, "other_statistics_fractions", {}) or {}
         capacity_mw = dp_value.effective_capacity_watts / 1_000_000
         target_time = dp_value.target_timestamp_utc.replace(microsecond=0)
-        if "p10" in other_stats:
-            properties["10"] = other_stats["p10"] * capacity_mw
-        if "p90" in other_stats:
-            properties["90"] = other_stats["p90"] * capacity_mw
+        for p in [2, 10, 25, 75, 90, 98]:
+            if f"p{p:02d}" in other_stats:
+                properties[str(p)] = other_stats[f"p{p:02d}"] * capacity_mw
 
         main_p50_mw = dp_value.p50_value_fraction * capacity_mw
 

--- a/forecast_blend/save.py
+++ b/forecast_blend/save.py
@@ -134,9 +134,12 @@ def map_values_df_to_dp_requests(
     horizons_mins = (target_datetime_utc - init_time_utc).total_seconds() / 60
     horizons_mins = horizons_mins.astype(int)
 
+    # the plevels (other than p50) that may be saved; National has all 7
+    other_p_levels = [2, 10, 25, 75, 90, 98]
+
     # get adjuster values
     if use_adjuster:
-        for p_col in ["p10_mw", "p50_mw", "p90_mw"]:
+        for p_col in ["p50_mw"] + [f"p{p}_mw" for p in other_p_levels]:
             if p_col in forecast_values_df.columns:
                 forecast_values_df[p_col] = (
                     forecast_values_df[p_col] - forecast_values_df["adjust_mw"]
@@ -147,29 +150,26 @@ def map_values_df_to_dp_requests(
     p50s = forecast_values_df["p50_mw"].values.astype(float)
     p50s = p50s * 1 * 10**6 / float(capacity_watts)
 
-    # add p10s and p90s if they exist
-    if "p10_mw" in forecast_values_df.columns:
-        p10s = forecast_values_df["p10_mw"].values.astype(float)
-        p10s = p10s * 1 * 10**6 / float(capacity_watts)
-    else:
-        p10s = [None] * len(p50s)
-    if "p90_mw" in forecast_values_df.columns:
-        p90s = forecast_values_df["p90_mw"].values.astype(float)
-        p90s = p90s * 1 * 10**6 / float(capacity_watts)
-    else:
-        p90s = [None] * len(p50s)
+    # convert each available plevel to a fraction of capacity
+    p_fractions = {}
+    for p in other_p_levels:
+        p_col = f"p{p}_mw"
+        if p_col in forecast_values_df.columns:
+            p_fractions[p] = (
+                forecast_values_df[p_col].values.astype(float) * 1 * 10**6 / float(capacity_watts)
+            )
 
     forecast_values = []
-    for h, p50, p10, p90 in zip(horizons_mins, p50s, p10s, p90s, strict=True):
+    for i, (h, p50) in enumerate(zip(horizons_mins, p50s, strict=True)):
         if h < 0:
             # skip negative horizons
             continue
 
-        other_statistics_fractions = {}
-        if p10 is not None:
-            other_statistics_fractions["p10"] = p10
-        if p90 is not None:
-            other_statistics_fractions["p90"] = p90
+        other_statistics_fractions = {
+            f"p{p:02d}": fractions[i]
+            for p, fractions in p_fractions.items()
+            if not pd.isna(fractions[i])
+        }
 
         forecast_values.append(
             dp.CreateForecastRequestForecastValue(

--- a/tests/integration/test_read_from_data_platform.py
+++ b/tests/integration/test_read_from_data_platform.py
@@ -152,10 +152,10 @@ async def create_test_forecast(
         p50_fraction = v["p50_mw"] * 1e6 / capacity_watts
 
         other_stats = {}
-        if "p10_mw" in v:
-            other_stats["p10"] = v["p10_mw"] * 1e6 / capacity_watts
-        if "p90_mw" in v:
-            other_stats["p90"] = v["p90_mw"] * 1e6 / capacity_watts
+        for p in [2, 10, 25, 75, 90, 98]:
+            p_col = f"p{p}_mw"
+            if p_col in v:
+                other_stats[f"p{p:02d}"] = v[p_col] * 1e6 / capacity_watts
 
         dp_values.append(
             dp.CreateForecastRequestForecastValue(
@@ -233,14 +233,18 @@ async def test_read_forecast_values_from_data_platform(
     client, _, _ = dp_client
     test_data = setup_test_data
 
-    # Create a forecast
+    # Create a National forecast carrying all 7 plevels (p50 plus the 6 others)
     init_time = datetime.datetime(2025, 1, 2, 12, 0, tzinfo=datetime.UTC)
     expected_values = [
         {
             "target_time": init_time + datetime.timedelta(minutes=30 * i),
             "p50_mw": 100 + i * 10,
+            "p2_mw": 80 + i * 10,
             "p10_mw": 90 + i * 10,
+            "p25_mw": 95 + i * 10,
+            "p75_mw": 105 + i * 10,
             "p90_mw": 110 + i * 10,
+            "p98_mw": 120 + i * 10,
         }
         for i in range(1, 9)
     ]
@@ -272,6 +276,23 @@ async def test_read_forecast_values_from_data_platform(
     )
 
     assert len(values) == 8, f"Expected 8 forecast values, got {len(values)}"
+
+    # Reading via get_forecast_values_from_data_platform should recover all 6 non-p50
+    # plevels in the properties dict, converted back to MW
+    df = await get_forecast_values_from_data_platform(
+        client=client,
+        location_uuid=location_uuid,
+        model_name="pvnet_day_ahead",
+        start_datetime=start_datetime,
+        gsp_id=1,
+    )
+
+    assert len(df) == 8
+    properties = df.sort_values("target_time")["properties"].iloc[0]
+    assert set(properties.keys()) == {"2", "10", "25", "75", "90", "98"}
+    assert properties["2"] == pytest.approx(90.0)
+    assert properties["10"] == pytest.approx(100.0)
+    assert properties["98"] == pytest.approx(130.0)
 
 
 @pytest.mark.asyncio(loop_scope="module")

--- a/tests/integration/test_save_to_data_platform.py
+++ b/tests/integration/test_save_to_data_platform.py
@@ -84,9 +84,13 @@ async def test_save_to_generation_to_data_platform(client):
     # setup: make fake data
     fake_data = pd.DataFrame(
         {
+            "p2_mw": [0.2] * 24,
             "p10_mw": [0.3] * 24,
+            "p25_mw": [0.4] * 24,
             "p50_mw": [0.5] * 24,
+            "p75_mw": [0.6] * 24,
             "p90_mw": [0.7] * 24,
+            "p98_mw": [0.8] * 24,
             "adjust_mw": [0.1] * 24,
             "target_datetime_utc": pd.Timestamp("2025-01-01")
             + pd.timedelta_range(
@@ -143,6 +147,12 @@ async def test_save_to_generation_to_data_platform(client):
     count = 0
     async for d in stream_forecast_data_response:
         assert d.p50_fraction == 0.5
+        # all 6 non-p50 plevels are saved, with zero-padded keys (e.g. "p02")
+        other = dict(d.other_statistics_fractions)
+        assert set(other.keys()) == {"p02", "p10", "p25", "p75", "p90", "p98"}
+        assert other["p02"] == pytest.approx(0.2)
+        assert other["p10"] == pytest.approx(0.3)
+        assert other["p98"] == pytest.approx(0.8)
         count += 1
     assert count == 24
 

--- a/tests/test_blend.py
+++ b/tests/test_blend.py
@@ -96,13 +96,16 @@ async def test_get_blend_forecast_values_latest_two_model_read_one():
         )
     )
 
+    props_0 = {"2": 0.5, "10": 0.9, "25": 0.95, "75": 1.05, "90": 1.1, "98": 1.5}
+    props_1 = {"2": 1.0, "10": 1.8, "25": 1.9, "75": 2.1, "90": 2.2, "98": 3.0}
+
     df1 = _make_df("test_1", [
-        [datetime(2023, 1, 1, tzinfo=timezone.utc), 1, 0, _now(), {"10": 0.9, "90": 1.1}, "test_1"],
-        [datetime(2023, 1, 1, 0, 30, tzinfo=timezone.utc), 2, 0, _now(), {"10": 1.8, "90": 2.2}, "test_1"],
+        [datetime(2023, 1, 1, tzinfo=timezone.utc), 1, 0, _now(), props_0, "test_1"],
+        [datetime(2023, 1, 1, 0, 30, tzinfo=timezone.utc), 2, 0, _now(), props_1, "test_1"],
     ])
     df2 = _make_df("test_2", [
-        [datetime(2023, 1, 1, tzinfo=timezone.utc), 1, 0, _now(), {"10": 0.9, "90": 1.1}, "test_2"],
-        [datetime(2023, 1, 1, 0, 30, tzinfo=timezone.utc), 2, 0, _now(), {"10": 1.8, "90": 2.2}, "test_2"],
+        [datetime(2023, 1, 1, tzinfo=timezone.utc), 1, 0, _now(), props_0, "test_2"],
+        [datetime(2023, 1, 1, 0, 30, tzinfo=timezone.utc), 2, 0, _now(), props_1, "test_2"],
     ])
 
     with patch("forecast_blend.blend.fetch_dp_latest_forecasts", new=AsyncMock(return_value=[])), \
@@ -119,10 +122,20 @@ async def test_get_blend_forecast_values_latest_two_model_read_one():
     assert len(result) == 2
     assert result.iloc[0]["p50_mw"] == 1
     assert result.iloc[1]["p50_mw"] == 2
+
+    for col in ["p2_mw", "p10_mw", "p25_mw", "p75_mw", "p90_mw", "p98_mw"]:
+        assert col in result.columns
+    assert result.iloc[0]["p2_mw"] == 0.5
     assert result.iloc[0]["p10_mw"] == 0.9
     assert result.iloc[0]["p90_mw"] == 1.1
+    assert result.iloc[0]["p98_mw"] == 1.5
+    assert result.iloc[1]["p2_mw"] == 1.0
     assert result.iloc[1]["p10_mw"] == 1.8
     assert result.iloc[1]["p90_mw"] == 2.2
+    assert result.iloc[1]["p98_mw"] == 3.0
+
+    # the properties dict keeps all 6 non-p50 plevels
+    assert result.iloc[0]["properties"] == props_0
 
 
 @pytest.mark.asyncio(loop_scope="session")


### PR DESCRIPTION
# Pull Request

## Description

- added support for extra plevels (p2, p10, p25 p50, p75, p90 and p98)
- updated tests 

Fixes #https://github.com/openclimatefix/client-private/issues/499

## How Has This Been Tested?

- [x] tested with dev data-platform

## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my code and corrected any misspellings
